### PR TITLE
feat: add support for poetry gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,14 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version: 10.5.0
+      - name: Setup Python
+        uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 #v4
+        with:
+          python-version: '3.11.4'
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@192395c0d10c082a7c62294ab5d9a9de40e48974 #v2
+        with:
+          poetry-version: '1.5.1'
       - name: Install dependencies with npm
         working-directory: 'npm/test'
         run: npm install


### PR DESCRIPTION
Tests [fail](https://github.com/opensbom-generator/parsers/actions/runs/5269868350/jobs/9528585714?pr=63) when running for poetry. This PR adds support for failing tests by setting up Python and poetry